### PR TITLE
Score; Tiles; Board

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,20 @@
-.idea
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+
+.config/*
+go.*

--- a/README.md
+++ b/README.md
@@ -3,37 +3,38 @@
 
  # 2048-go
  
-[2048](http://gabrielecirulli.github.io/2048/) in CLI. It's made from Golang 
-2048 is a great game made by JavaScript.
-This app works on command and helps your sabotage.
+[2048](http://gabrielecirulli.github.io/2048/), except in CLI form, via Golang.  
+2048 is a great game written in JavaScript.  
+This app works on command-line and helps your self-sabotage.  
 
 # Screen shot
 
-[![asciicast](https://asciinema.org/a/jkyqRNv1yWi8E59cUCIQSjiit.png)](https://asciinema.org/a/jkyqRNv1yWi8E59cUCIQSjiit)
+[![asciicast](https://asciinema.org/a/jkyqRNv1yWi8E59cUCIQSjiit.png)](https://asciinema.org/a/jkyqRNv1yWi8E59cUCIQSjiit)  
 
 
 # How to install
 
-You should install go
+You should install go  
 
 # License
 
-2048-go is licensed under the [MIT license.](https://github.com/1984weed/2048-go/blob/master/LICENSE.txt)
+2048-go is licensed under the [MIT license.](https://github.com/1984weed/2048-go/blob/master/LICENSE.txt)  
 
 
 
 
 ## Mac
-
-I only checked this environment.
-
+```shell
+$ brew install go
+$ export PATH=$GOPATH:$PATH
+$ go get github.com/1984weed/2048-go
+$ 2048-go
 ```
-brew install go
-export PATH=$GOPATH:$PATH
-```
 
-```
-go get github.com/1984weed/2048-go
-2048-go
+## Windows
+```powershell
+> choco install go
+> go get github.com/1984weed/2048-go
+> 2048-go
 ```
 

--- a/application.go
+++ b/application.go
@@ -13,8 +13,6 @@ import (
 	"strconv"
 )
 
-// const game_width int = 40 / 2
-// const game_height int = 40 / 2
 const GAME_TOP_OFFSET = 1
 
 type Tile struct {
@@ -83,6 +81,8 @@ func handleKeyEvent() {
 			case termbox.KeyEsc:
 				return
 			case termbox.KeySpace:
+				return
+			case termbox.KeyEnter:
 				return
 			case termbox.KeyArrowDown:
 				dispatch("down", &Message{data: "push left"})
@@ -356,7 +356,7 @@ var (
 func main() {
 	flag.BoolVar(&debugRun, "debug", false, "debugRun flag")
 	flag.IntVar(&rowLength, "rowLength", 4, "set the number of tiles per row")
-	flag.IntVar(&tileSize, "tileSize", 8, "set the size of the square tiles")
+	flag.IntVar(&tileSize, "tileSize", 4, "set the size of the square tiles")
 	flag.Parse()
 	
 	game_width = tileSize * 10

--- a/utils_test.go
+++ b/utils_test.go
@@ -8,7 +8,10 @@ func TestReverseList(t *testing.T) {
 	actual := []int{1, 2, 3, 4, 5}
 	expected := []int{5, 4, 3, 2, 1}
 	ReverseList(actual)
-
+	
+	if len(actual) != len(expected) {
+		t.Errorf("%v should have the same length as %v", actual, expected)
+	}
 	for i := 0; i < len(actual); i++ {
 		if actual[i] != expected[i] {
 			t.Errorf("%v should be equal to %v", actual, expected)


### PR DESCRIPTION
- Problem: Config file appearing in random directories
  - Cause: I'm on windows and os.Getenv("HOME") doesn't work  
  - Solution change os.Getenv to os.UserHomeDir with a fallback to the directory in which the built executable is located  
- Problem: window too large for my screen
  - Solution: add a flag to control the tile size
    - Note: while implementing, I mistakenly chreated a flag for the number of tiles per row. I liked the idea of strange board shapes so I kept the flag after finding the solution  